### PR TITLE
coalesce NSNull -> nil

### DIFF
--- a/ADNKit/ANKResource.m
+++ b/ADNKit/ANKResource.m
@@ -169,6 +169,11 @@ static dispatch_once_t propertiesMapOnceToken;
 		
 		// next, pull out the value and class of the value
 		id value = JSONDictionary[JSONKey];
+		// treat omitted value the same as explicit null
+		if (value == [NSNull null]) {
+			value = nil;
+		}
+
 		Class valueClass = [value class];
 		NSString *valueClassString = NSStringFromClass(valueClass);
 		


### PR DESCRIPTION
In general, the API omits any "falsy" value (which means this
would return nil), but in certain cases we do include an
explicit null, which can break things.
