### PR TITLE
Don't crash if errorID is null

### DIFF
--- a/ADNKit/ANKAPIResponseMeta.m
+++ b/ADNKit/ANKAPIResponseMeta.m
@@ -31,7 +31,7 @@
 	NSError *error = nil;
 	
 	if (self.isError) {
-		error = [NSError errorWithDomain:kANKErrorDomain code:self.statusCode userInfo:@{NSLocalizedDescriptionKey: self.errorMessage, kANKErrorTypeKey: @(self.errorType), kANKErrorIDKey: self.errorID}];
+		error = [NSError errorWithDomain:kANKErrorDomain code:self.statusCode userInfo:@{NSLocalizedDescriptionKey: self.errorMessage, kANKErrorTypeKey: @(self.errorType), kANKErrorIDKey: self.errorID ?: @""}];
 	}
 	
 	return error;


### PR DESCRIPTION
This can happen sometimes (but it's rare).
