### PR TITLE
A fix for a bug in "-fetchPostsStarredByUserWithID: completion:" (ANKClient+ANKPost)

### DIFF
--- a/ADNKit/ANKClient+ANKPost.m
+++ b/ADNKit/ANKClient+ANKPost.m
@@ -60,7 +60,7 @@
 
 
 - (void)fetchPostsStarredByUserWithID:(NSString *)userID completion:(ANKClientCompletionBlock)completionHandler {
-	[self getPath:[NSString stringWithFormat:@"posts/%@/stars", userID]
+	[self getPath:[NSString stringWithFormat:@"users/%@/stars", userID]
 	   parameters:nil
 		  success:[self successHandlerForCollectionOfResourceClass:[ANKPost class] clientHandler:completionHandler]
 		  failure:[self failureHandlerForClientHandler:completionHandler]];


### PR DESCRIPTION
This function was trying to fetch a user's favorite posts list using "posts/%@{userID}/stars" when the correct is "users/%@{userID}/stars". Fixed :)
