### PR TITLE
Feature/dw fix json dictionary infinite loop

### DIFF
--- a/ADNKit/ANKEntities.m
+++ b/ADNKit/ANKEntities.m
@@ -30,7 +30,7 @@
 @implementation ANKEntities
 
 + (NSSet *)localKeysExcludedFromJSONOutput {
-	return [[super localKeysExcludedFromJSONOutput] setByAddingObjectsFromArray:@[@"text"]];
+	return [[super localKeysExcludedFromJSONOutput] setByAddingObjectsFromArray:@[@"text", @"mentionMap"]];
 }
 
 

--- a/ADNKit/ANKEntity.m
+++ b/ADNKit/ANKEntity.m
@@ -21,6 +21,11 @@
 }
 
 
++ (NSSet *)localKeysExcludedFromJSONOutput {
+	return [[super localKeysExcludedFromJSONOutput] setByAddingObjectsFromArray:@[@"parentEntities"]];
+}
+
+
 - (NSRange)range {
 	return [self.parentEntities rangeForEntity:self];
 }

--- a/ADNKit/ANKResource.m
+++ b/ADNKit/ANKResource.m
@@ -134,7 +134,7 @@ static dispatch_once_t propertiesMapOnceToken;
 
 
 + (NSSet *)localKeysExcludedFromJSONOutput {
-	return nil;
+	return [[NSSet alloc] init];
 }
 
 


### PR DESCRIPTION
When calling JSONDictionary on an ANKEntities object, it could go into an infinite loop. This fixes that by excluding the mentionMap and parentEntities local properties
