### PR TITLE
Two quick fixes

### DIFF
--- a/ADNKit/ANKClient.m
+++ b/ADNKit/ANKClient.m
@@ -99,14 +99,25 @@
 
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method path:(NSString *)path parameters:(NSDictionary *)parameters {
-	NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
+	NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
+
+	NSMutableDictionary *commonParameters = [NSMutableDictionary dictionary];
+
 	if (self.generalParameters) {
-		[mutableParameters addEntriesFromDictionary:[self.generalParameters JSONDictionary]];
+		[commonParameters addEntriesFromDictionary:[self.generalParameters JSONDictionary]];
 	}
+
 	if (self.pagination) {
-		[mutableParameters addEntriesFromDictionary:[self.pagination JSONDictionary]];
+		[commonParameters addEntriesFromDictionary:[self.pagination JSONDictionary]];
 	}
-	return [super requestWithMethod:method path:path parameters:mutableParameters.count ? mutableParameters : nil];
+
+	if (commonParameters.count) {
+		NSString *encodedParameters = AFQueryStringFromParametersWithEncoding(commonParameters, self.stringEncoding);
+		NSString *URLString = [request.URL absoluteString];
+		request.URL = [NSURL URLWithString:[URLString stringByAppendingFormat:[URLString rangeOfString:@"?"].location == NSNotFound ? @"?%@" : @"&%@", encodedParameters]];
+	}
+
+	return request;
 }
 
 

--- a/ADNKit/ANKPaginationSettings.m
+++ b/ADNKit/ANKPaginationSettings.m
@@ -31,7 +31,7 @@
 }
 
 
-+ (instancetype)settingsWithCount:(NSInteger)count {
++ (instancetype)settingsWithCount:(NSUInteger)count {
 	return [[self class] settingsWithSinceID:nil beforeID:nil count:count];
 }
 


### PR DESCRIPTION
We require pagination parameters to be in the query string. Also, fix a compiler warning based on signed/unsigned mismatch between .h and .m. Negative counts don't make sense unless other pagination params are specified, so I opted to make this unsigned.
