### PR TITLE
Add new API to post ADNPost objects with a replyTo

### DIFF
--- a/ADNKit/ANKClient+ANKPost.h
+++ b/ADNKit/ANKClient+ANKPost.h
@@ -27,6 +27,9 @@
 - (ANKJSONRequestOperation *)fetchPostsStarredByUserWithID:(NSString *)userID completion:(ANKClientCompletionBlock)completionHandler;
 
 - (ANKJSONRequestOperation *)createPost:(ANKPost *)post completion:(ANKClientCompletionBlock)completionHandler;
+- (ANKJSONRequestOperation *)createPost:(ANKPost *)post inReplyToPost:(ANKPost *)replyToPost completion:(ANKClientCompletionBlock)completionHandler;
+- (ANKJSONRequestOperation *)createPost:(ANKPost *)post inReplyToPostWithID:(NSString *)postID completion:(ANKClientCompletionBlock)completionHandler;
+
 - (ANKJSONRequestOperation *)createPostWithText:(NSString *)text completion:(ANKClientCompletionBlock)completionHandler;
 - (ANKJSONRequestOperation *)createPostWithText:(NSString *)text inReplyToPost:(ANKPost *)post completion:(ANKClientCompletionBlock)completionHandler;
 - (ANKJSONRequestOperation *)createPostWithText:(NSString *)text inReplyToPostWithID:(NSString *)postID completion:(ANKClientCompletionBlock)completionHandler;

--- a/ADNKit/ANKClient+ANKPost.m
+++ b/ADNKit/ANKClient+ANKPost.m
@@ -76,6 +76,20 @@
 						 failure:[self failureHandlerForClientHandler:completionHandler]];
 }
 
+- (ANKJSONRequestOperation *)createPost:(ANKPost *)post inReplyToPost:(ANKPost *)replyToPost completion:(ANKClientCompletionBlock)completionHandler {
+    return [self createPost:post inReplyToPostWithID:replyToPost.postID completion:completionHandler];
+}
+
+- (ANKJSONRequestOperation *)createPost:(ANKPost *)post inReplyToPostWithID:(NSString *)postID completion:(ANKClientCompletionBlock)completionHandler {
+    NSMutableDictionary *parametersTemp = [[post JSONDictionary] mutableCopy];
+    if (postID)
+        parametersTemp[@"reply_to"] = postID;
+	return [self enqueuePOSTPath:@"posts"
+					  parameters:[parametersTemp copy]
+						 success:[self successHandlerForResourceClass:[ANKPost class] clientHandler:completionHandler]
+						 failure:[self failureHandlerForClientHandler:completionHandler]];
+}
+
 
 - (ANKJSONRequestOperation *)createPostWithText:(NSString *)text completion:(ANKClientCompletionBlock)completionHandler {
 	return [self createPostWithText:text inReplyToPostWithID:nil completion:completionHandler];


### PR DESCRIPTION
Hi, I am in the process of converting my project (which uses Matt Rubin's AppDotNet) to using ADNKit.  I've got most of my app converted over.  I hit a bit of a snag though, in that to post an ADNPost in reply to another, using Matt's AppDotNet I could simply do:

``` objective-c
ADNPost *myPost = [[ADNPost alloc] init];
myPost.text = @"Hello World";
// set up other stuff like annotations, file oembeds, etc.
myPost.replyToId = replyToPost.postId;
```

I didn't see anything comparable in ADNKit.  I could use `[[ANKClient sharedClient] createPostWithText:myPost.text inReplyToPost:replyToPost completion:...]` but that doesn't let me add annotations or otherwise customize the ANKPost object, etc.

What would be ideal is something like `[[ANKClient sharedClient] createPost:(ANKPost *)post inReplyToPost:(ANKPost *)replyToPost completion:...]`  Which is exactly what I just created.  (I also threw in `[[ANKClient sharedClient] createPost:(ANKPost *)post inReplyToPostWithID:(NSString *)postID completion:...]` at no extra charge. ;-) )

The only thing I will say of my code is that it works.  In particular I'm sure there's probably a more efficient way of creating the parameters dictionary (rather than copying to an NSMutableDictionary, adding necessary objects and then copying back which is what I did).  Would appreciate some pointers there.
