### PR TITLE
API additions to support Ohai

### DIFF
--- a/ADNKit/ANKAnnotatableResource.h
+++ b/ADNKit/ANKAnnotatableResource.h
@@ -16,5 +16,6 @@
 @interface ANKAnnotatableResource : ANKResource
 
 @property (strong) NSArray *annotations;
+-(NSArray *)annotationsWithType:(NSString *)type;
 
 @end

--- a/ADNKit/ANKAnnotatableResource.m
+++ b/ADNKit/ANKAnnotatableResource.m
@@ -20,4 +20,10 @@
 	return [ANKAnnotation class];
 }
 
+-(NSArray *)annotationsWithType:(NSString *)type{
+	return [self.annotations ank_filter:^BOOL(ANKAnnotation *annotation) {
+		return [annotation.type isEqualToString:type];
+	}];
+}
+
 @end

--- a/ADNKit/ANKClient+ANKChannel.h
+++ b/ADNKit/ANKClient+ANKChannel.h
@@ -18,6 +18,7 @@
 @interface ANKClient (ANKChannel)
 
 - (ANKJSONRequestOperation *)fetchCurrentUserSubscribedChannelsWithCompletion:(ANKClientCompletionBlock)completionHandler;
+- (ANKJSONRequestOperation *)fetchCurrentUserSubscribedChannelsWithTypes:(NSArray *)types completion:(ANKClientCompletionBlock)completionHandler;
 - (ANKJSONRequestOperation *)fetchCurrentUserPrivateMessageChannelsWithCompletion:(ANKClientCompletionBlock)completionHandler;
 - (ANKJSONRequestOperation *)fetchCurrentUserCreatedChannelsWithCompletion:(ANKClientCompletionBlock)completionHandler;
 - (ANKJSONRequestOperation *)fetchUnreadPMChannelsCountWithCompletion:(ANKClientCompletionBlock)completionHandler;

--- a/ADNKit/ANKClient+ANKChannel.m
+++ b/ADNKit/ANKClient+ANKChannel.m
@@ -27,6 +27,17 @@
 						failure:[self failureHandlerForClientHandler:completionHandler]];
 }
 
+- (ANKJSONRequestOperation *)fetchCurrentUserSubscribedChannelsWithTypes:(NSArray *)types completion:(ANKClientCompletionBlock)completionHandler {
+	if (!types) {
+		types = @[];
+	}
+	
+	return [self enqueueGETPath:@"channels"
+					 parameters:@{ @"channel_types": [types componentsJoinedByString:@","] }
+						success:[self successHandlerForCollectionOfResourceClass:[ANKChannel class] clientHandler:completionHandler]
+						failure:[self failureHandlerForClientHandler:completionHandler]];
+}
+
 
 - (ANKJSONRequestOperation *)fetchCurrentUserPrivateMessageChannelsWithCompletion:(ANKClientCompletionBlock)completionHandler {
 	return [self enqueueGETPath:@"channels" parameters:nil success:[self successHandlerForCollectionOfResourceClass:[ANKChannel class] clientHandler:completionHandler filteredWith:^BOOL(id object) {

--- a/ADNKit/ANKClient+ANKFile.h
+++ b/ADNKit/ANKClient+ANKFile.h
@@ -22,6 +22,7 @@
 - (ANKJSONRequestOperation *)fetchCurrentUserFilesWithCompletion:(ANKClientCompletionBlock)completionHandler;
 - (AFHTTPRequestOperation *)fetchContentsOfFile:(ANKFile *)file completion:(ANKClientCompletionBlock)completionHandler;
 - (AFHTTPRequestOperation *)fetchContentsOfFileWithID:(NSString *)fileID completion:(ANKClientCompletionBlock)completionHandler;
+- (AFHTTPRequestOperation *)fetchContentsOfFileWithID:(NSString *)fileID withReadToken:(NSString *)readToken completion:(ANKClientCompletionBlock)completionHandler;
 
 - (ANKJSONRequestOperation *)createFile:(ANKFile *)file withData:(NSData *)fileData completion:(ANKClientCompletionBlock)completionHandler;
 - (ANKJSONRequestOperation *)createFile:(ANKFile *)file withContentsOfURL:(NSURL *)fileURL progress:(ANKClientFileUploadProgressBlock)progressHandler completion:(ANKClientCompletionBlock)completionHandler;

--- a/ADNKit/ANKClient+ANKFile.m
+++ b/ADNKit/ANKClient+ANKFile.m
@@ -55,7 +55,16 @@
 
 
 - (AFHTTPRequestOperation *)fetchContentsOfFileWithID:(NSString *)fileID completion:(ANKClientCompletionBlock)completionHandler {
-	NSURLRequest *request = [self requestWithMethod:@"GET" path:[NSString stringWithFormat:@"files/%@/content", fileID] parameters:nil];
+	return [self fetchContentsOfFileWithID:fileID withReadToken:nil completion:completionHandler];
+}
+
+- (AFHTTPRequestOperation *)fetchContentsOfFileWithID:(NSString *)fileID withReadToken:(NSString *)readToken completion:(ANKClientCompletionBlock)completionHandler {
+	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+	if (readToken) {
+		parameters[@"file_token"] = readToken;
+	}
+
+	NSURLRequest *request = [self requestWithMethod:@"GET" path:[NSString stringWithFormat:@"files/%@/content", fileID] parameters:[parameters copy]];
 	AFHTTPRequestOperation *requestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
 	[requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
 		if (completionHandler) {

--- a/ADNKit/ANKClient.h
+++ b/ADNKit/ANKClient.h
@@ -53,6 +53,7 @@ typedef void (^ANKClientCompletionBlock)(id responseObject, ANKAPIResponseMeta *
 @property (assign) ANKResponseDecodingType responseDecodingType;
 
 @property (assign) BOOL shouldRequestAnnotations; // when yes, annotations will be fetched regardless of the object type
+@property (assign) BOOL shouldRequestMachineOnlyPosts; // when yes, machine-only posts will be fetched regardless of the object type
 @property (assign) BOOL shouldUseSharedUserDefaultsController; // default NO - uses [NSUserDefaults standardUserDefaults] when NO, [[NSUserDefaultsController sharedUserDefaultsController] defaults] when YES.
 @property (assign) BOOL shouldSynchronizeOnUserDefaultsWrite; // default NO - if set to YES, will call synchronize on each write to make sure that user defaults are written to disk immediately
 

--- a/ADNKit/ANKClient.m
+++ b/ADNKit/ANKClient.m
@@ -100,7 +100,16 @@
 
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method path:(NSString *)path parameters:(NSDictionary *)parameters {
-	NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:parameters];
+	NSMutableDictionary *mutableParameters = parameters ? [parameters mutableCopy] : [NSMutableDictionary dictionary];
+
+	if (self.shouldRequestAnnotations) {
+        mutableParameters[@"include_annotations"] = @1;
+	}
+	if (self.shouldRequestMachineOnlyPosts) {
+        mutableParameters[@"include_machine"] = @1;
+	}
+	
+	NSMutableURLRequest *request = [super requestWithMethod:method path:path parameters:[mutableParameters copy]];
 
 	NSMutableDictionary *commonParameters = [NSMutableDictionary dictionary];
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Note: the basic core structure of this framework is based off of [Matt Rubin](ht
 * [Stream] (http://getstreamapp.net) by [@kolin] (https://alpha.app.net/kolin) and [@christian] (https://alpha.app.net/christian)
 * Dot by [@nerd] (https://alpha.app.net/nerd) and [@amc] (https://alpha.app.net/amc)
 * [Dayspring](http://thedunahoos.com/dayspring)  by [@nerd] (https://alpha.app.net/nerd) and [@amc] (https://alpha.app.net/amc)
+* [Ohai] (http://ohaiapp.net/) by [@stevestreza] (https://alpha.app.net/stevestreza)
 * *Multiple unannounced projects*
 
 *Please file an issue to get your app added if you'd like to be on the list!*


### PR DESCRIPTION
Ohai needed a few API additions to ADNKit, and they are included here.
- Support for filtering annotations by type on ANKAnnotatableResource
- Support for requesting machine-only posts on ANKClient
- Support for requesting files using specific read-only tokens
- Support for fetching subscribed ANKChannels, limited to specific types

I've tried to maintain the coding styles and patterns the project already uses, but I'm happy to make any changes desired.
