### PR TITLE
Fixed urlForSize bug

### DIFF
--- a/ADNKit/ANKImage.m
+++ b/ADNKit/ANKImage.m
@@ -26,27 +26,28 @@
 
 
 - (NSURL *)URLForSize:(CGSize)size {
-	NSURL *URL = self.URL;
-
-	if (size.width > 0 || size.height > 0) {
-		NSMutableString *s = [NSMutableString stringWithFormat:@"%@?", URL.absoluteString];
-		if (size.width > 0) {
-			[s appendFormat:@"w=%u", (unsigned int)size.width];
-
-			if (size.height > 0) {
-				[s appendFormat:@"&"];
-			}
-		}
-
-		if (size.height > 0) {
-			[s appendFormat:@"h=%u", (unsigned int)size.height];
-		}
-
-		URL = [NSURL URLWithString:s];
-	}
-
-	return URL;
+    NSURL *URL = self.URL;
+    
+    if (size.width > 0 || size.height > 0) {
+        
+        NSString *queryExtension = (URL.query && URL.query.length) ? @"&" : @"?";
+        NSMutableString *s = [NSMutableString stringWithFormat:@"%@%@", URL.absoluteString, queryExtension];
+        
+        if (size.width > 0) {
+            [s appendFormat:@"w=%u", (unsigned int)size.width];
+            if (size.height > 0) {
+                [s appendString:@"&"];
+            }
+        }
+        
+        if (size.height > 0) {
+            [s appendFormat:@"h=%u", (unsigned int)size.height];
+        }
+        
+        URL = [NSURL URLWithString:s];
+    }
+    
+    return URL;
 }
-
 
 @end


### PR DESCRIPTION
I already mentioned this in Issue #54.
urlForSize of ANKImage didn't check whether the URL already has arguments. The method in this pull request fixes that.
