### PR TITLE
A few improvements to ANKSearchQuery

### DIFF
--- a/ADNKit.xcodeproj/project.pbxproj
+++ b/ADNKit.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		5DC3727E16E3AF6900190862 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DC3727D16E3AF6900190862 /* UIKit.framework */; };
 		5DC3728116E3AF8900190862 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DC3728016E3AF8800190862 /* CoreLocation.framework */; };
 		5DC3728316E3AF8E00190862 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DC3728216E3AF8E00190862 /* SystemConfiguration.framework */; };
+		E2D5E6E017D8FBEE00EABFD9 /* ANKSearchQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 331B250E17A247DF000E553E /* ANKSearchQuery.m */; };
 		F153F9AA1773C1DE0018BC16 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F153F9A91773C1DE0018BC16 /* Security.framework */; };
 /* End PBXBuildFile section */
 
@@ -1300,6 +1301,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2D5E6E017D8FBEE00EABFD9 /* ANKSearchQuery.m in Sources */,
 				2592B7C616FF8410004573FF /* ANKClient.m in Sources */,
 				2592B7C716FF8410004573FF /* ANKACL.m in Sources */,
 				2592B7C816FF8410004573FF /* ANKAnnotatableResource.m in Sources */,

--- a/ADNKit/ANKClient+ANKPost.m
+++ b/ADNKit/ANKClient+ANKPost.m
@@ -191,7 +191,7 @@
 - (ANKJSONRequestOperation *)searchForPostsWithQuery:(ANKSearchQuery *)query completion:(ANKClientCompletionBlock)completionHandler {
     return [self enqueueGETPath:@"posts/search"
                      parameters:[query JSONDictionary]
-                        success:[self successHandlerForResourceClass:[ANKPost class] clientHandler:completionHandler]
+                        success:[self successHandlerForCollectionOfResourceClass:[ANKPost class] clientHandler:completionHandler]
                         failure:[self failureHandlerForClientHandler:completionHandler]];
 }
 

--- a/ADNKit/ANKSearchQuery.m
+++ b/ADNKit/ANKSearchQuery.m
@@ -54,7 +54,7 @@
 {
     if ((self = [super init])) {
         self.indexType = kANKSearchQueryIndexTypeComplete;
-        self.orderType = kANKSearchQueryOrderTypeScore;
+        self.orderType = kANKSearchQueryOrderTypeID;
     }
 
     return self;

--- a/ADNKit/ANKValueTransformations.h
+++ b/ADNKit/ANKValueTransformations.h
@@ -28,6 +28,7 @@
 // reverse transformations
 - (id)JSONObjectFromNSURL:(NSURL *)URL;
 - (id)JSONObjectFromNSDate:(NSDate *)date;
+- (id)JSONObjectFromNSArray:(NSArray *)array;
 
 // misc
 - (NSDateFormatter *)dateFormatter;

--- a/ADNKit/ANKValueTransformations.m
+++ b/ADNKit/ANKValueTransformations.m
@@ -71,5 +71,8 @@
 	return [[self dateFormatter] stringFromDate:date];
 }
 
+- (id)JSONObjectFromNSArray:(NSArray *)array {
+    return [array componentsJoinedByString:@","];
+}
 
 @end


### PR DESCRIPTION
ANKSearchQuery missing from ADNKit-AFNetworking-iOS target,
order type should default to id,
search should return array of posts, not just a single Post (this fails)
