### PR TITLE
Adding rate limit information to ANKAPIResponseMeta

### DIFF
--- a/ADNKit/ANKAPIResponse.h
+++ b/ADNKit/ANKAPIResponse.h
@@ -23,6 +23,6 @@ static NSString *const kANKAPIResponseKey = @"ANKAPIResponse";
 @property (readonly, strong) id data;
 @property (readonly, strong) ANKAPIResponseMeta *meta;
 
-- (id)initWithResponseObject:(id)responseObject;
+- (id)initWithResponseObject:(id)responseObject andHeaders:(NSDictionary*)headers;
 
 @end

--- a/ADNKit/ANKAPIResponse.m
+++ b/ADNKit/ANKAPIResponse.m
@@ -24,12 +24,20 @@
 
 @implementation ANKAPIResponse
 
-- (id)initWithResponseObject:(id)responseObject {
+- (id)initWithResponseObject:(id)responseObject andHeaders:(NSDictionary*)headers{
 	if ((self = [super init])) {
 		if ([responseObject isKindOfClass:[NSDictionary class]]) {
 			NSDictionary *responseDictionary = (NSDictionary *)responseObject;
 			self.data = responseDictionary[@"data"];
 			self.meta = [ANKAPIResponseMeta objectFromJSONDictionary:responseDictionary[@"meta"]];
+			
+			if (headers)
+			{
+				self.meta.rateLimitReset = [headers objectForKey:@"X-RateLimit-Reset"];
+				self.meta.rateLimitRemaining = [headers objectForKey:@"X-RateLimit-Remaining"];
+				self.meta.rateLimitLimit = [headers objectForKey:@"X-RateLimit-Limit"];
+				self.meta.rateLimitRetryAfter = [headers objectForKey:@"Retry-After"];
+			}
 		}
 	}
 	return self;

--- a/ADNKit/ANKAPIResponseMeta.h
+++ b/ADNKit/ANKAPIResponseMeta.h
@@ -59,6 +59,12 @@ static NSString *const kANKErrorIDKey = @"ANKErrorID";
 @property (strong) NSString *errorSlug;
 @property (strong) NSString *errorID;
 
+@property (strong) NSString *rateLimitRemaining;
+@property (strong) NSString *rateLimitLimit;
+@property (strong) NSString *rateLimitReset;
+@property (strong) NSString *rateLimitRetryAfter;
+
+
 - (NSError *)error;
 - (BOOL)isError;
 - (ANKErrorType)errorType;

--- a/ADNKit/ANKJSONRequestOperation.m
+++ b/ADNKit/ANKJSONRequestOperation.m
@@ -19,13 +19,15 @@
 
 - (void)setCompletionBlockWithSuccess:(void (^)(AFHTTPRequestOperation *, id))success failure:(void (^)(AFHTTPRequestOperation *, NSError *))failure {
 	[super setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
-		ANKAPIResponse *response = [[ANKAPIResponse alloc] initWithResponseObject:responseObject];
+		NSDictionary* headers = operation.response.allHeaderFields;
+		ANKAPIResponse *response = [[ANKAPIResponse alloc] initWithResponseObject:responseObject andHeaders:headers];
 		
 		if (success) {
 			success(operation, response);
 		}
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-		ANKAPIResponse *response = [[ANKAPIResponse alloc] initWithResponseObject:((AFJSONRequestOperation *)operation).responseJSON];
+		NSDictionary* headers = operation.response.allHeaderFields;
+		ANKAPIResponse *response = [[ANKAPIResponse alloc] initWithResponseObject:((AFJSONRequestOperation *)operation).responseJSON andHeaders:headers];
 		
 		NSMutableDictionary *modifiedUserInfo = [error.userInfo mutableCopy];
 		modifiedUserInfo[kANKAPIResponseKey] = response;


### PR DESCRIPTION
Currently there's no way to access the rate limit header responses from functions that use the ANKClientCompletionBlock. This is a fairly simple change to expose the NSURLHTTPResponse headers to the ANKAPIResponse which then adds the rate limit information to the meta object. This change also makes it easier to expose/add other header response values if needed in the future.
