### PR TITLE
Allow count=0 through to the API

### DIFF
--- a/ADNKit/ANKPaginationSettings.m
+++ b/ADNKit/ANKPaginationSettings.m
@@ -12,6 +12,7 @@
 
 #import "ANKPaginationSettings.h"
 
+static const NSInteger kANKPaginationSettingsUndefinedCount = NSIntegerMax;
 
 @implementation ANKPaginationSettings
 
@@ -62,11 +63,18 @@
 	return settings;
 }
 
+- (instancetype)init {
+    if ((self = [super init])) {
+        self.count = kANKPaginationSettingsUndefinedCount;
+    }
+
+    return self;
+}
 
 - (NSDictionary *)JSONDictionary {
 	NSDictionary *dictionary = [super JSONDictionary];
 	
-	if ([dictionary[@"count"] integerValue] == 0) {
+	if ([dictionary[@"count"] integerValue] == kANKPaginationSettingsUndefinedCount) {
 		NSMutableDictionary *modifiedDictionary = [dictionary mutableCopy];
 		[modifiedDictionary removeObjectForKey:@"count"];
 		dictionary = modifiedDictionary;


### PR DESCRIPTION
I'm very new to objective-c so maybe this is protecting against other "falsey" objects, but being able to pass count=0 makes it very easy to subscribe to user streams when you don't care about old data and only want new data.
