### PR TITLE
Allow multiple streaming operations to be started

### DIFF
--- a/ADNKit/ANKClient.m
+++ b/ADNKit/ANKClient.m
@@ -422,6 +422,8 @@ static const NSString *kANKUserStreamEndpointURL = @"wss://stream-channel.app.ne
         } else if (operation.isReady) {
             [operation start];
         }
+    } else if (self.socketShuttle.socketState == KATSocketStateConnecting){
+        [operation pause];
     }
 
     [self.streamContexts addObject:[ANKStreamContext streamContextWithOperation:operation identifier:subscriptionID delegate:delegate]];


### PR DESCRIPTION
When trying to subscribe to multiple UserStream topics, only the
first one was succeeding (since it got paused and then resumed on
didReceiveMessage in the isInitialConnectionResponse state). This
pauses subsequent operations that come in while we're trying to
connect the websocket so once we successfully connect, we can
resume (and subscribe with the correct connection_id).
