### PR TITLE
ADNKit-OSX had the iOS SocketShuttle as a target dependency, fixed.

### DIFF
--- a/ADNKit.xcodeproj/project.pbxproj
+++ b/ADNKit.xcodeproj/project.pbxproj
@@ -253,7 +253,7 @@
 		252E632617421632003143D6 /* ANKClient+ANKStreamMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = 252E632417421632003143D6 /* ANKClient+ANKStreamMarker.m */; };
 		252E632717421632003143D6 /* ANKClient+ANKStreamMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = 252E632417421632003143D6 /* ANKClient+ANKStreamMarker.m */; };
 		252E632817421632003143D6 /* ANKClient+ANKStreamMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = 252E632417421632003143D6 /* ANKClient+ANKStreamMarker.m */; };
-		2567680F1711539D00C57D47 /* NSString+ANKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2567680D1711539D00C57D47 /* NSString+ANKAdditions.h */; };
+		2567680F1711539D00C57D47 /* NSString+ANKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2567680D1711539D00C57D47 /* NSString+ANKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		256768101711539D00C57D47 /* NSString+ANKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2567680E1711539D00C57D47 /* NSString+ANKAdditions.m */; };
 		256768111711539D00C57D47 /* NSString+ANKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2567680E1711539D00C57D47 /* NSString+ANKAdditions.m */; };
 		256768121711539D00C57D47 /* NSString+ANKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2567680E1711539D00C57D47 /* NSString+ANKAdditions.m */; };

--- a/ADNKit.xcodeproj/project.pbxproj
+++ b/ADNKit.xcodeproj/project.pbxproj
@@ -447,19 +447,19 @@
 			remoteGlobalIDString = 4DE9EB64170D870A005B295E;
 			remoteInfo = SocketShuttle;
 		};
-		25D01E1217641047000D365D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 25D01E0517640FF1000D365D /* SocketShuttle.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 4DE9EB64170D870A005B295E;
-			remoteInfo = SocketShuttle;
-		};
 		330BDCA81765945F009BD559 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 25D01E0517640FF1000D365D /* SocketShuttle.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 4DE9EB64170D870A005B295E;
 			remoteInfo = SocketShuttle;
+		};
+		902756DC18B3076E00CB0579 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 25D01E0517640FF1000D365D /* SocketShuttle.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 905AF99E17BB3F40002FDE4E;
+			remoteInfo = SocketShuttleOSX;
 		};
 		905AF9D617BB41AD002FDE4E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1366,7 +1366,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				25D01E1317641047000D365D /* PBXTargetDependency */,
+				902756DD18B3076E00CB0579 /* PBXTargetDependency */,
 			);
 			name = "ADNKit-OSX";
 			productName = "ADNKit-OSX";
@@ -1711,15 +1711,15 @@
 			name = SocketShuttle;
 			targetProxy = 25D01E0F17641021000D365D /* PBXContainerItemProxy */;
 		};
-		25D01E1317641047000D365D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SocketShuttle;
-			targetProxy = 25D01E1217641047000D365D /* PBXContainerItemProxy */;
-		};
 		330BDCA91765945F009BD559 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SocketShuttle;
 			targetProxy = 330BDCA81765945F009BD559 /* PBXContainerItemProxy */;
+		};
+		902756DD18B3076E00CB0579 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SocketShuttleOSX;
+			targetProxy = 902756DC18B3076E00CB0579 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
This is in support of #53.
