### PR TITLE
Added support for parse_markdown_links

### DIFF
--- a/ADNKit/ANKEntities.h
+++ b/ADNKit/ANKEntities.h
@@ -22,6 +22,7 @@
 @property (strong) NSArray *hashtags;
 @property (strong) NSArray *links;
 @property (assign) BOOL parseLinks;
+@property (assign) BOOL parseMarkdownLinks;
 
 - (ANKMentionEntity *)mentionForUsername:(NSString *)username;
 - (BOOL)containsMentionForUsername:(NSString *)username;

--- a/ADNKit/ANKEntities.m
+++ b/ADNKit/ANKEntities.m
@@ -35,7 +35,7 @@
 
 
 + (NSDictionary *)JSONToLocalKeyMapping {
-	return [[super JSONToLocalKeyMapping] ank_dictionaryByAppendingDictionary:@{@"parse_links": @"parseLinks"}];
+	return [[super JSONToLocalKeyMapping] ank_dictionaryByAppendingDictionary:@{@"parse_links": @"parseLinks", @"parse_markdown_links": @"parseMarkdownLinks"}];
 }
 
 


### PR DESCRIPTION
Now ADNKit can support inline markdown links.
