### PR TITLE
Adds configurable response_type in the web auth flow.

### DIFF
--- a/ADNKit/ANKClient.h
+++ b/ADNKit/ANKClient.h
@@ -68,6 +68,10 @@ typedef void (^ANKClientCompletionBlock)(id responseObject, ANKAPIResponseMeta *
 
 // web-style authentication. call this method first, and then load the resulting URLRequest is a webview
 - (NSURLRequest *)webAuthRequestForClientID:(NSString *)clientID redirectURI:(NSString *)redirectURI authScopes:(ANKAuthScope)authScopes state:(NSString *)state appStoreCompliant:(BOOL)shouldBeAppStoreCompliant;
+
+// web-style authentication, with a configurable responseType. Set this to @"code" for default behaviour, and @"token" for the implicit grant flow.
+- (NSURLRequest *)webAuthRequestForClientID:(NSString *)clientID redirectURI:(NSString *)redirectURI authScopes:(ANKAuthScope)authScopes state:(NSString *)state responseType:(NSString *) responseType appStoreCompliant:(BOOL)shouldBeAppStoreCompliant;
+
 // once you have an access code, call this method to finish web auth
 - (void)authenticateWebAuthAccessCode:(NSString *)accessCode forClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret;
 

--- a/ADNKit/ANKClient.m
+++ b/ADNKit/ANKClient.m
@@ -130,9 +130,19 @@
 
 
 - (NSURLRequest *)webAuthRequestForClientID:(NSString *)clientID redirectURI:(NSString *)redirectURI authScopes:(ANKAuthScope)authScopes state:(NSString *)state appStoreCompliant:(BOOL)shouldBeAppStoreCompliant {
+    
+    return [self webAuthRequestForClientID:clientID
+                               redirectURI:redirectURI
+                                authScopes:authScopes
+                                     state:state
+                              responseType:@"code"
+                         appStoreCompliant:shouldBeAppStoreCompliant];
+}
+
+- (NSURLRequest *)webAuthRequestForClientID:(NSString *)clientID redirectURI:(NSString *)redirectURI authScopes:(ANKAuthScope)authScopes state:(NSString *)state responseType:(NSString *) responseType appStoreCompliant:(BOOL)shouldBeAppStoreCompliant {
 	// http://developers.app.net/docs/authentication/flows/web/
 	self.webAuthRedirectURI = redirectURI;
-	NSMutableString *URLString = [NSMutableString stringWithFormat:@"https://account.app.net/oauth/authenticate?client_id=%@&response_type=code", clientID];
+	NSMutableString *URLString = [NSMutableString stringWithFormat:@"https://account.app.net/oauth/authenticate?client_id=%@&response_type=%@", clientID, responseType];
 	
 	if (authScopes) {
 		[URLString appendFormat:@"&scope=%@", [[self class] scopeStringForAuthScopes:authScopes]];


### PR DESCRIPTION
This lets you use the implicit grant flow (response_type=token),
which means you don't need to store the app secret in the binary
anymore.
