### PR TITLE
Fix busted fetchMessagesWithIDs method

### DIFF
--- a/ADNKit/ANKClient+ANKMessage.m
+++ b/ADNKit/ANKClient+ANKMessage.m
@@ -51,7 +51,7 @@
 
 - (ANKJSONRequestOperation *)fetchMessagesWithIDs:(NSArray *)messageIDs completion:(ANKClientCompletionBlock)completionHandler {
 	return [self enqueueGETPath:@"channels/messages"
-					 parameters:nil
+					 parameters:@{@"ids": [messageIDs componentsJoinedByString:@","]}
 						success:[self successHandlerForCollectionOfResourceClass:[ANKMessage class] clientHandler:completionHandler]
 						failure:[self failureHandlerForClientHandler:completionHandler]];
 }


### PR DESCRIPTION
The messageIDs array was totally being ignored here, always resulting in an empty NSArray responseObject.
